### PR TITLE
remove built in verifier creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,10 @@ yarn add passport-fast-jwt
 
 ## Usage
 
-The first argument is a JWT verifier function created with fast-jwt `createVerifier` or alternatively options to be used when creating one. If the options are passed, the strategy creates a verifier function using `fast-jwt` with the given options. You can read more about verifier options from [fast-jwt docs](https://github.com/nearform/fast-jwt?tab=readme-ov-file#createverifier).
+The first argument must be a JWT verifier function created with fast-jwt `createVerifier`. You can read more about creating verifier from [fast-jwt docs](https://github.com/nearform/fast-jwt?tab=readme-ov-file#createverifier).
 
 ```typescript
-type ConstructionArgumentss = [
-  VerifierOptions | Verifier,
-  TokenExtractor,
-  AfterVerifyCallback,
-]
-
-type VerifierOptions = FastJWT.VerifierOptions & {
-  key?:
-    | string
-    | Buffer
-    | ((DecodedJwt: FastJWT.DecodedJwt) => Promise<string | Buffer>)
-}
+type ConstructionArgumentss = [Verifier, TokenExtractor, AfterVerifyCallback]
 
 type Verifier =
   | typeof FastJWT.VerifierSync
@@ -68,34 +57,7 @@ passport.use(
     })
   }),
 )
-// *-----------* OR *-----------*
-const verifierOptions = { key: async () => "secret", cache: true }
-const tokenExtractor1 = Extractors.fromHeader("token-header")
-const tokenExtractor2 = Extractors.fromAuthHeaderWithScheme(
-  "x-authorization",
-  "x-bearer",
-)
-
-const tokenExtractors = fromExtractors([tokenExtractor1, tokenExtractor2])
-
-passport.use(
-  new JwtStrategy(verifierOptions, tokenExtractors, (sections, done, req) => {
-    User.findOne({ id: sections.payload.sub }, (error, user) => {
-      if (error) {
-        return done(err, false)
-      }
-      if (!user) {
-        return done(null, false, "User not found", 404)
-      }
-      return done(null, user)
-    })
-  }),
-)
 ```
-
-### Fast-JWT createVerifier options
-
-All [Fast-JWT verifier options](https://github.com/nearform/fast-jwt?tab=readme-ov-file#createverifier) can be passed as the `fastJwtOptions`. However, all options combinations haven't been tested yet, so proceed with caution. If you find any problems with some options, please raise an issue.
 
 ### Verification callback
 
@@ -135,7 +97,7 @@ someRouter.use("/someRoute", (req, res, next) =>
     { session: false },
     (err: any, user: Express.User, info: any) => {
       if (err) {
-        console.log("Error happened, need to do something to it")
+        console.error("Error happened, need to do something to it")
         next(err)
       }
     },

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ type AfterVerifyCallback = (
 const jwtVerifier = FastJWT.createVerifier({ ...verifierOptions })
 const tokenExtractor = Extractors.fromHeader("token-header")
 
-passport.use(
-  new JwtStrategy(jwtVerifier, tokenExtractor, (sections, done, req) => {
+const JwtStrategy = new JwtStrategy(
+  jwtVerifier,
+  tokenExtractor,
+  (sections, done, req) => {
     User.findOne({ id: sections.payload.sub }, (error, user) => {
       if (error) {
         return done(err, false)
@@ -55,8 +57,10 @@ passport.use(
       }
       return done(null, user)
     })
-  }),
+  },
 )
+
+passport.use(JwtStrategy)
 ```
 
 ### Verification callback

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -4,32 +4,12 @@ import FastJWT from "fast-jwt"
 import Passport from "passport"
 import PassportStrategy from "passport-strategy"
 
-import {
-  AfterVerifyCallback,
-  CArgs,
-  TokenExtractor,
-  Verifier,
-  VerifierOptions,
-} from "./types"
+import { AfterVerifyCallback, TokenExtractor, Verifier } from "./types"
 
 /**
  * @example
  * ```typescript
  * passport.use(new JwtStrategy(jwtVerifier, tokenExtractor, (sections, done, req) => {
- *   User.findOne({ id: sections.payload.sub }, (error, user) => {
- *     if (error) {
- *       return done(err, false)
- *     }
- *     if (!user) {
- *       return done(null, false, "User not found", 404)
- *     }
- *     return done(null, user)
- *   })
- * }))
- *
- * // *-----------* OR *-----------*
- *
- * passport.use(new JwtStrategy(verifierOptions, tokenExtractor, (sections, done, req) => {
  *   User.findOne({ id: sections.payload.sub }, (error, user) => {
  *     if (error) {
  *       return done(err, false)
@@ -50,50 +30,15 @@ export class JwtStrategy extends PassportStrategy.Strategy {
   private afterVerifiedCb: AfterVerifyCallback
 
   constructor(
-    verifierOptions: VerifierOptions,
-    tokenExtractor: TokenExtractor,
-    afterVerifiedCb: AfterVerifyCallback,
-  )
-  constructor(
     jwtVerifier: Verifier,
     tokenExtractor: TokenExtractor,
     afterVerifiedCb: AfterVerifyCallback,
-  )
-  constructor(...args: CArgs) {
+  ) {
     super()
     this.name = "jwt"
-
-    if (typeof args[0] === "function") {
-      this.verifyJwt = args[0]
-    } else {
-      const { key, ...opts } = args[0]
-
-      /**
-       * Just making TS happy here
-       *
-       * If algorithms is "none", the key must not be provided
-       */
-      if (opts.algorithms?.includes("none")) {
-        if (key) {
-          console.warn(
-            "Key was provided even though algorithms include none. Fast JWT says that if no algorithm is used, they key must not be provided. Thus the provided key parameter will be removed from verifier options",
-          )
-        }
-        this.verifyJwt = FastJWT.createVerifier({ ...opts })
-      } else if (typeof key === "string" || key instanceof Buffer) {
-        this.verifyJwt = FastJWT.createVerifier({
-          ...opts,
-          key: key as string | Buffer,
-        })
-      } else {
-        this.verifyJwt = FastJWT.createVerifier({
-          ...opts,
-          key: key as FastJWT.KeyFetcher,
-        })
-      }
-    }
-    this.extractToken = args[1]
-    this.afterVerifiedCb = args[2]
+    this.verifyJwt = jwtVerifier
+    this.extractToken = tokenExtractor
+    this.afterVerifiedCb = afterVerifiedCb
   }
 
   private createSections(


### PR DESCRIPTION
# Breaking change!

* JwtStrategy no longer accepts `verifierOptions` as the first parameter
* Only verifier created with FastJWT createVerifier is accepted

Remove the built in verifier creation from verifier options. Initial idea was to remove the need to install the fast-jwt as a dependency. However, creating the verifier inside the strategy means that it will be created every time an endpoint using the strategy is called, IF the strategy is created inline as shown in older docs. Creating the strategy and verifier inline adds unnecessary processing, so it's better to always create the verifier separately and pass in as a parameter. Also if the verifier was created inside the strategy, it would have to be supported. This way we can separate the responsibilities and the passport strategy gets simpler.